### PR TITLE
ログインステータスに応じたリダイレクト処理の実装

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "endOfLine": "lf"
+}

--- a/src/About.tsx
+++ b/src/About.tsx
@@ -5,7 +5,7 @@ const About: FC = () => {
     <React.Fragment>
       <h1>Aboutページです</h1>
     </React.Fragment>
-  )
-}
+  );
+};
 
 export default About;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,14 +63,14 @@ const App: FC = () => {
           exact
           path='/login'
           render={() => (
-            <Login setIsLoggedIn={setIsLoggedIn}/>
+            <Login isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>
           )}
         />
         <Route
           exact
           path='/signup'
           render={() => (
-            <SignUp setIsLoggedIn={setIsLoggedIn}/>
+            <SignUp isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>
           )}
         />
         <Auth isLoggedIn={isLoggedIn}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Home from './Home';
 import About from './About';
 import Login from './Login';
 import SignUp from './Signup';
+import Auth from './Auth';
 
 const App: FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -56,8 +57,8 @@ const App: FC = () => {
           </li>
         </ul>
       </nav>
+  
       <Switch>
-        <Route path='/about' component={About} exact />
         <Route
           exact
           path='/login'
@@ -72,7 +73,10 @@ const App: FC = () => {
             <SignUp setIsLoggedIn={setIsLoggedIn}/>
           )}
         />
-        <Route path='/' component={Home} />
+        <Auth isLoggedIn={isLoggedIn}>
+          <Route path='/about' component={About} exact />
+          <Route path='/' component={Home} />
+        </Auth>
         <Redirect to='/' />
       </Switch>
     </React.Fragment>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ const App: FC = () => {
   useEffect(() => {
     axios
       .get(`${process.env.REACT_APP_API_HOST}/logged_in`, { withCredentials: true })
-      .then(res => {
+      .then((res) => {
         setIsLoggedIn(res.data.logged_in);
       });
   }, []);
@@ -24,63 +24,58 @@ const App: FC = () => {
   const handleLogoutClick = () => {
     axios
       .delete(`${process.env.REACT_APP_API_HOST}/logout`, { withCredentials: true })
-      .then(res => {
+      .then((res) => {
         console.log('Logout success!');
         setIsLoggedIn(false);
         history.push('/login');
-      }).catch(err => {
+      })
+      .catch((err) => {
         console.log('Logout falied', err);
       });
-  }
+  };
 
   return (
     <React.Fragment>
       <nav>
         <ul>
           <li>
-            <Link to='/'>Home</Link>
+            <Link to="/">Home</Link>
           </li>
           <li>
-            <Link to='/about'>About</Link>
+            <Link to="/about">About</Link>
           </li>
           <li>
-            <Link to='/login'>Login</Link>
+            <Link to="/login">Login</Link>
           </li>
           <li>
-            <Link to='/signup'>Signup</Link>
+            <Link to="/signup">Signup</Link>
           </li>
           <li>
             <button onClick={handleLogoutClick}>ログアウト</button>
           </li>
-          <li>
-            { isLoggedIn ? 'ログイン中です' : 'ログインしてません' }
-          </li>
+          <li>{isLoggedIn ? 'ログイン中です' : 'ログインしてません'}</li>
         </ul>
       </nav>
-  
+
       <Switch>
         <Route
           exact
-          path='/login'
-          render={() => (
-            <Login isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>
-          )}
+          path="/login"
+          render={() => <Login isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
         />
         <Route
           exact
-          path='/signup'
-          render={() => (
-            <SignUp isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>
-          )}
+          path="/signup"
+          render={() => <SignUp isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
         />
         <Auth isLoggedIn={isLoggedIn}>
-          <Route path='/about' component={About} exact />
-          <Route path='/' component={Home} />
+          <Route path="/about" component={About} exact />
+          <Route path="/" component={Home} />
         </Auth>
-        <Redirect to='/' />
+        <Redirect to="/" />
       </Switch>
     </React.Fragment>
-  )
-}
+  );
+};
 
 export default App;

--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from "react";
+import { Redirect } from "react-router-dom";
+
+type Props = {
+  isLoggedIn: boolean;
+};
+
+const Auth: FC<Props> = ({ isLoggedIn, children }) => {
+  return (
+    <React.Fragment>
+      {isLoggedIn ? children : <Redirect to={"/login"} />}
+    </React.Fragment>
+  );
+};
+
+export default Auth;

--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -1,16 +1,12 @@
-import React, { FC } from "react";
-import { Redirect } from "react-router-dom";
+import React, { FC } from 'react';
+import { Redirect } from 'react-router-dom';
 
 type Props = {
   isLoggedIn: boolean;
 };
 
 const Auth: FC<Props> = ({ isLoggedIn, children }) => {
-  return (
-    <React.Fragment>
-      {isLoggedIn ? children : <Redirect to={"/login"} />}
-    </React.Fragment>
-  );
+  return <React.Fragment>{isLoggedIn ? children : <Redirect to={'/login'} />}</React.Fragment>;
 };
 
 export default Auth;

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -4,15 +4,15 @@ import axios from 'axios';
 const Home: FC = () => {
   const [message, setMessage] = useState('こんにちは');
   const fetchMessage = () => {
-   axios
-    .get(`${process.env.REACT_APP_API_HOST}`)
-    .then(res => {
-      setMessage(res.data.message);
-    })
-    .catch(error => {
-      console.error(error);
-    })
-  }
+    axios
+      .get(`${process.env.REACT_APP_API_HOST}`)
+      .then((res) => {
+        setMessage(res.data.message);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  };
 
   return (
     <React.Fragment>
@@ -20,7 +20,7 @@ const Home: FC = () => {
       <h2>{message}</h2>
       <button onClick={fetchMessage}>Change message</button>
     </React.Fragment>
-  )
-}
+  );
+};
 
 export default Home;

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -46,9 +46,9 @@ const useStyles = makeStyles((theme) => ({
 type LoginProps = {
   isLoggedIn: boolean;
   setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
-}
+};
 
-const Login: FC<LoginProps> = ({isLoggedIn, setIsLoggedIn}) => {
+const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
   const classes = useStyles();
 
   const [email, setEmail] = useState('');
@@ -58,93 +58,104 @@ const Login: FC<LoginProps> = ({isLoggedIn, setIsLoggedIn}) => {
 
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault();
-    axios.post(`${process.env.REACT_APP_API_HOST}/login`, {
-      session: {
-        email: email,
-        password: password,
-      }
-    },
-    { withCredentials: true }
-    ).then(res => {
-      console.log('login success', res);
-      setIsLoggedIn(true);
-      history.push('/');
-    }).catch(error => {
-      console.log('login error', error)
-    });
-  }
+    axios
+      .post(
+        `${process.env.REACT_APP_API_HOST}/login`,
+        {
+          session: {
+            email: email,
+            password: password,
+          },
+        },
+        { withCredentials: true }
+      )
+      .then((res) => {
+        console.log('login success', res);
+        setIsLoggedIn(true);
+        history.push('/');
+      })
+      .catch((error) => {
+        console.log('login error', error);
+      });
+  };
 
   return (
     <React.Fragment>
-      { isLoggedIn ? <Redirect to={'/'} /> :
-      <Container component="main" maxWidth="xs">
-        <CssBaseline />
-        <div className={classes.paper}>
-          <Avatar className={classes.avatar}>
-            <LockOutlinedIcon />
-          </Avatar>
-          <Typography component="h1" variant="h5">
-            LOGIN
-          </Typography>
-          <form className={classes.form} noValidate>
-            <TextField
-              variant="outlined"
-              margin="normal"
-              required
-              fullWidth
-              id="email"
-              label="Email"
-              name="email"
-              autoComplete="email"
-              autoFocus
-              value={email}
-              // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
-              onChange={e => { setEmail(e.target.value) }}
-            />
-            <TextField
-              variant="outlined"
-              margin="normal"
-              required
-              fullWidth
-              name="password"
-              label="Password"
-              type="password"
-              id="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={e => { setPassword(e.target.value) }}
-            />
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              color="primary"
-              className={classes.submit}
-              onClick={handleSubmit}
-            >
-              ログイン
-            </Button>
-            <Grid container justify='center'>
-              {/* <Grid item xs>
+      {isLoggedIn ? (
+        <Redirect to={'/'} />
+      ) : (
+        <Container component="main" maxWidth="xs">
+          <CssBaseline />
+          <div className={classes.paper}>
+            <Avatar className={classes.avatar}>
+              <LockOutlinedIcon />
+            </Avatar>
+            <Typography component="h1" variant="h5">
+              LOGIN
+            </Typography>
+            <form className={classes.form} noValidate>
+              <TextField
+                variant="outlined"
+                margin="normal"
+                required
+                fullWidth
+                id="email"
+                label="Email"
+                name="email"
+                autoComplete="email"
+                autoFocus
+                value={email}
+                // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                }}
+              />
+              <TextField
+                variant="outlined"
+                margin="normal"
+                required
+                fullWidth
+                name="password"
+                label="Password"
+                type="password"
+                id="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                }}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                color="primary"
+                className={classes.submit}
+                onClick={handleSubmit}
+              >
+                ログイン
+              </Button>
+              <Grid container justify="center">
+                {/* <Grid item xs>
                 <Link href="#" variant="body2">
                   Forgot password?
                 </Link>
               </Grid> */}
-              <Grid item>
-                <Link href="#" variant="body2">
-                  {"アカウントをお持ちでない方はこちら"}
-                </Link>
+                <Grid item>
+                  <Link href="#" variant="body2">
+                    {'アカウントをお持ちでない方はこちら'}
+                  </Link>
+                </Grid>
               </Grid>
-            </Grid>
-          </form>
-        </div>
-        <Box mt={8}>
-          <Copyright />
-        </Box>
-      </Container>
-      }
+            </form>
+          </div>
+          <Box mt={8}>
+            <Copyright />
+          </Box>
+        </Container>
+      )}
     </React.Fragment>
   );
-}
+};
 
 export default Login;

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState, FC } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, Redirect } from 'react-router-dom';
 import axios from 'axios';
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
@@ -43,9 +43,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type LoginProps = { setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>> }
+type LoginProps = {
+  isLoggedIn: boolean;
+  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
-const Login: FC<LoginProps> = ({setIsLoggedIn}) => {
+const Login: FC<LoginProps> = ({isLoggedIn, setIsLoggedIn}) => {
   const classes = useStyles();
 
   const [email, setEmail] = useState('');
@@ -72,71 +75,75 @@ const Login: FC<LoginProps> = ({setIsLoggedIn}) => {
   }
 
   return (
-    <Container component="main" maxWidth="xs">
-      <CssBaseline />
-      <div className={classes.paper}>
-        <Avatar className={classes.avatar}>
-          <LockOutlinedIcon />
-        </Avatar>
-        <Typography component="h1" variant="h5">
-          LOGIN
-        </Typography>
-        <form className={classes.form} noValidate>
-          <TextField
-            variant="outlined"
-            margin="normal"
-            required
-            fullWidth
-            id="email"
-            label="Email"
-            name="email"
-            autoComplete="email"
-            autoFocus
-            value={email}
-            // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
-            onChange={e => { setEmail(e.target.value) }}
-          />
-          <TextField
-            variant="outlined"
-            margin="normal"
-            required
-            fullWidth
-            name="password"
-            label="Password"
-            type="password"
-            id="password"
-            autoComplete="current-password"
-            value={password}
-            onChange={e => { setPassword(e.target.value) }}
-          />
-          <Button
-            type="submit"
-            fullWidth
-            variant="contained"
-            color="primary"
-            className={classes.submit}
-            onClick={handleSubmit}
-          >
-            ログイン
-          </Button>
-          <Grid container justify='center'>
-            {/* <Grid item xs>
-              <Link href="#" variant="body2">
-                Forgot password?
-              </Link>
-            </Grid> */}
-            <Grid item>
-              <Link href="#" variant="body2">
-                {"アカウントをお持ちでない方はこちら"}
-              </Link>
+    <React.Fragment>
+      { isLoggedIn ? <Redirect to={'/'} /> :
+      <Container component="main" maxWidth="xs">
+        <CssBaseline />
+        <div className={classes.paper}>
+          <Avatar className={classes.avatar}>
+            <LockOutlinedIcon />
+          </Avatar>
+          <Typography component="h1" variant="h5">
+            LOGIN
+          </Typography>
+          <form className={classes.form} noValidate>
+            <TextField
+              variant="outlined"
+              margin="normal"
+              required
+              fullWidth
+              id="email"
+              label="Email"
+              name="email"
+              autoComplete="email"
+              autoFocus
+              value={email}
+              // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
+              onChange={e => { setEmail(e.target.value) }}
+            />
+            <TextField
+              variant="outlined"
+              margin="normal"
+              required
+              fullWidth
+              name="password"
+              label="Password"
+              type="password"
+              id="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={e => { setPassword(e.target.value) }}
+            />
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              color="primary"
+              className={classes.submit}
+              onClick={handleSubmit}
+            >
+              ログイン
+            </Button>
+            <Grid container justify='center'>
+              {/* <Grid item xs>
+                <Link href="#" variant="body2">
+                  Forgot password?
+                </Link>
+              </Grid> */}
+              <Grid item>
+                <Link href="#" variant="body2">
+                  {"アカウントをお持ちでない方はこちら"}
+                </Link>
+              </Grid>
             </Grid>
-          </Grid>
-        </form>
-      </div>
-      <Box mt={8}>
-        <Copyright />
-      </Box>
-    </Container>
+          </form>
+        </div>
+        <Box mt={8}>
+          <Copyright />
+        </Box>
+      </Container>
+      }
+    </React.Fragment>
   );
 }
 

--- a/src/Signup.tsx
+++ b/src/Signup.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState, FormEvent } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, Redirect } from 'react-router-dom';
 import axios from 'axios';
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
@@ -46,9 +46,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type SignupProps = { setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>> }
+type SignupProps = {
+  isLoggedIn: boolean;
+  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
-const Signup: FC<SignupProps> = ({setIsLoggedIn}) => {
+const Signup: FC<SignupProps> = ({isLoggedIn, setIsLoggedIn}) => {
   const classes = useStyles();
 
   const [email, setEmail] = useState('');
@@ -77,6 +80,8 @@ const Signup: FC<SignupProps> = ({setIsLoggedIn}) => {
   }
 
   return (
+    <React.Fragment>
+    { isLoggedIn ? <Redirect to={'/'} /> :
     <Container component="main" maxWidth="xs">
       <CssBaseline />
       <div className={classes.paper}>
@@ -154,6 +159,8 @@ const Signup: FC<SignupProps> = ({setIsLoggedIn}) => {
         <Copyright />
       </Box>
     </Container>
+    }
+    </React.Fragment>
   );
 }
 

--- a/src/Signup.tsx
+++ b/src/Signup.tsx
@@ -49,9 +49,9 @@ const useStyles = makeStyles((theme) => ({
 type SignupProps = {
   isLoggedIn: boolean;
   setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
-}
+};
 
-const Signup: FC<SignupProps> = ({isLoggedIn, setIsLoggedIn}) => {
+const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
   const classes = useStyles();
 
   const [email, setEmail] = useState('');
@@ -62,106 +62,119 @@ const Signup: FC<SignupProps> = ({isLoggedIn, setIsLoggedIn}) => {
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    axios.post(`${process.env.REACT_APP_API_HOST}/users`, {
-      user: {
-        email: email,
-        password: password,
-        password_confirmation: passwordConfirmation
-      }
-    },
-    { withCredentials: true }
-    ).then(res => {
-      console.log('signup success', res);
-      setIsLoggedIn(true);
-      history.push('/');
-    }).catch(error => {
-      console.log('signup error', error)
-    });
-  }
+    axios
+      .post(
+        `${process.env.REACT_APP_API_HOST}/users`,
+        {
+          user: {
+            email: email,
+            password: password,
+            password_confirmation: passwordConfirmation,
+          },
+        },
+        { withCredentials: true }
+      )
+      .then((res) => {
+        console.log('signup success', res);
+        setIsLoggedIn(true);
+        history.push('/');
+      })
+      .catch((error) => {
+        console.log('signup error', error);
+      });
+  };
 
   return (
     <React.Fragment>
-    { isLoggedIn ? <Redirect to={'/'} /> :
-    <Container component="main" maxWidth="xs">
-      <CssBaseline />
-      <div className={classes.paper}>
-        <Avatar className={classes.avatar}>
-          <LockOutlinedIcon />
-        </Avatar>
-        <Typography component="h1" variant="h5">
-          新規登録
-        </Typography>
-        <form className={classes.form} noValidate>
-          <Grid container spacing={2}>
-            <Grid item xs={12}>
-              <TextField
-                variant="outlined"
-                required
+      {isLoggedIn ? (
+        <Redirect to={'/'} />
+      ) : (
+        <Container component="main" maxWidth="xs">
+          <CssBaseline />
+          <div className={classes.paper}>
+            <Avatar className={classes.avatar}>
+              <LockOutlinedIcon />
+            </Avatar>
+            <Typography component="h1" variant="h5">
+              新規登録
+            </Typography>
+            <form className={classes.form} noValidate>
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <TextField
+                    variant="outlined"
+                    required
+                    fullWidth
+                    id="email"
+                    label="Email"
+                    name="email"
+                    autoComplete="email"
+                    value={email}
+                    // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    variant="outlined"
+                    required
+                    fullWidth
+                    name="password"
+                    label="Password"
+                    type="password"
+                    id="password"
+                    autoComplete="current-password"
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    variant="outlined"
+                    required
+                    fullWidth
+                    name="passwordConfirmation"
+                    label="Password Confirmation"
+                    type="password"
+                    id="passwordConfirmation"
+                    autoComplete="current-password"
+                    value={passwordConfirmation}
+                    onChange={(e) => {
+                      setPasswordConfirmation(e.target.value);
+                    }}
+                  />
+                </Grid>
+              </Grid>
+              <Button
+                type="submit"
                 fullWidth
-                id="email"
-                label="Email"
-                name="email"
-                autoComplete="email"
-                value={email}
-                // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
-                onChange={e => { setEmail(e.target.value) }}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                variant="outlined"
-                required
-                fullWidth
-                name="password"
-                label="Password"
-                type="password"
-                id="password"
-                autoComplete="current-password"
-                value={password}
-                onChange={e => { setPassword(e.target.value) }}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                variant="outlined"
-                required
-                fullWidth
-                name="passwordConfirmation"
-                label="Password Confirmation"
-                type="password"
-                id="passwordConfirmation"
-                autoComplete="current-password"
-                value={passwordConfirmation}
-                onChange={e => { setPasswordConfirmation(e.target.value) }}
-              />
-            </Grid>
-          </Grid>
-          <Button
-            type="submit"
-            fullWidth
-            variant="contained"
-            color="primary"
-            className={classes.submit}
-            onClick={handleSubmit}
-          >
-            Sign Up
-          </Button>
-          <Grid container justify="flex-end">
-            <Grid item>
-              <Link href="#" variant="body2">
-                Already have an account? Sign in
-              </Link>
-            </Grid>
-          </Grid>
-        </form>
-      </div>
-      <Box mt={5}>
-        <Copyright />
-      </Box>
-    </Container>
-    }
+                variant="contained"
+                color="primary"
+                className={classes.submit}
+                onClick={handleSubmit}
+              >
+                Sign Up
+              </Button>
+              <Grid container justify="flex-end">
+                <Grid item>
+                  <Link href="#" variant="body2">
+                    Already have an account? Sign in
+                  </Link>
+                </Grid>
+              </Grid>
+            </form>
+          </div>
+          <Box mt={5}>
+            <Copyright />
+          </Box>
+        </Container>
+      )}
     </React.Fragment>
   );
-}
+};
 
-export default Signup
+export default Signup;


### PR DESCRIPTION
close #12 

### やったこと
- [この記事](https://qiita.com/soutaito/items/691ac9dabe765e98d9f9)を参考に`Auth`コンポーネントを作成して未ログインユーザーを`/login`にリダイレクトさせる処理を実装
- `Login`コンポーネントと`SignUp`コンポーネントに、`isLoggedIn`の値を見てログインユーザーは`/`にリダイレクトさせる処理を追加
  - `Auth`コンポーネントのようなコンポーネントをもう１つ作ろうと思ったが、ネストが深くなって可読性が下がるのでやめた
  - 調べてみるとreduxとか使ってログイン状態をグローバルに管理しているケースが多かったが、現段階でそれを導入しようとするとtoo muchで実装が進まなくなりそうなのでこれもやめた
  - ログインユーザーを弾くページはおそらくこれから増えなさそうなのでこの実装にした
- `.prettirrc`を作成してコードのフォーマット
  - 設定ファイルは[この記事](https://ma-vericks.com/vscode-prettier/)から持ってきた
  - （設定したつもりだったけどできてなかった、、、）