### PR TITLE
Implement form validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.19.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^5.6.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "typescript": "~3.7.2"

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,6 +1,7 @@
-import React, { useState, FC } from 'react';
+import React, { FC } from 'react';
 import { useHistory, Redirect } from 'react-router-dom';
 import axios from 'axios';
+import { useForm } from 'react-hook-form';
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
 import CssBaseline from '@material-ui/core/CssBaseline';
@@ -48,16 +49,22 @@ type LoginProps = {
   setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
+type LoginFormData = {
+  email: string;
+  password: string;
+};
+
 const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
   const classes = useStyles();
 
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
   const history = useHistory();
 
-  const handleSubmit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault();
+  const { handleSubmit, register } = useForm<LoginFormData>();
+
+  const handleOnSubmit = (data: LoginFormData) => {
+    const { email, password } = data;
+    debugger;
+
     axios
       .post(
         `${process.env.REACT_APP_API_HOST}/login`,
@@ -93,7 +100,7 @@ const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
             <Typography component="h1" variant="h5">
               LOGIN
             </Typography>
-            <form className={classes.form} noValidate>
+            <form className={classes.form} noValidate onSubmit={handleSubmit(handleOnSubmit)}>
               <TextField
                 variant="outlined"
                 margin="normal"
@@ -104,11 +111,7 @@ const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                 name="email"
                 autoComplete="email"
                 autoFocus
-                value={email}
-                // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                }}
+                inputRef={register}
               />
               <TextField
                 variant="outlined"
@@ -120,10 +123,7 @@ const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                 type="password"
                 id="password"
                 autoComplete="current-password"
-                value={password}
-                onChange={(e) => {
-                  setPassword(e.target.value);
-                }}
+                inputRef={register}
               />
               <Button
                 type="submit"
@@ -131,7 +131,6 @@ const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                 variant="contained"
                 color="primary"
                 className={classes.submit}
-                onClick={handleSubmit}
               >
                 ログイン
               </Button>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -59,7 +59,7 @@ const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const history = useHistory();
 
-  const { handleSubmit, register } = useForm<LoginFormData>();
+  const { handleSubmit, register, errors } = useForm<LoginFormData>();
 
   const handleOnSubmit = (data: LoginFormData) => {
     const { email, password } = data;
@@ -111,7 +111,15 @@ const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                 name="email"
                 autoComplete="email"
                 autoFocus
-                inputRef={register}
+                inputRef={register({
+                  required: 'メールアドレスは必ず入力してください',
+                  pattern: {
+                    value: /^[\w+\-.]+@[a-z\d\-.]+\.[a-z]+$/,
+                    message: 'メールアドレスは正しい形式で入力してください',
+                  },
+                })}
+                error={!!errors.email}
+                helperText={!!errors.email && errors.email.message}
               />
               <TextField
                 variant="outlined"
@@ -123,7 +131,15 @@ const Login: FC<LoginProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                 type="password"
                 id="password"
                 autoComplete="current-password"
-                inputRef={register}
+                inputRef={register({
+                  required: 'パスワードは必ず入力してください',
+                  minLength: {
+                    value: 8,
+                    message: 'パスワードは8文字以上で入力してください',
+                  },
+                })}
+                error={!!errors.password}
+                helperText={!!errors.password && errors.password.message}
               />
               <Button
                 type="submit"

--- a/src/Signup.tsx
+++ b/src/Signup.tsx
@@ -1,6 +1,7 @@
-import React, { FC, useState, FormEvent } from 'react';
+import React, { FC } from 'react';
 import { useHistory, Redirect } from 'react-router-dom';
 import axios from 'axios';
+import { useForm } from 'react-hook-form';
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
 import CssBaseline from '@material-ui/core/CssBaseline';
@@ -51,17 +52,22 @@ type SignupProps = {
   setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
+type SignupFormData = {
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+};
+
 const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
   const classes = useStyles();
 
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [passwordConfirmation, setPasswordConfirmation] = useState('');
-
   const history = useHistory();
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
+  const { handleSubmit, register } = useForm<SignupFormData>();
+
+  const handleOnSubmit = (data: SignupFormData) => {
+    const { email, password, passwordConfirmation } = data;
+
     axios
       .post(
         `${process.env.REACT_APP_API_HOST}/users`,
@@ -98,7 +104,7 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
             <Typography component="h1" variant="h5">
               新規登録
             </Typography>
-            <form className={classes.form} noValidate>
+            <form className={classes.form} noValidate onSubmit={handleSubmit(handleOnSubmit)}>
               <Grid container spacing={2}>
                 <Grid item xs={12}>
                   <TextField
@@ -109,11 +115,7 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                     label="Email"
                     name="email"
                     autoComplete="email"
-                    value={email}
-                    // TODO: アンチパターンらしいのであとで修正する（他のフォームも同じ）
-                    onChange={(e) => {
-                      setEmail(e.target.value);
-                    }}
+                    inputRef={register}
                   />
                 </Grid>
                 <Grid item xs={12}>
@@ -126,10 +128,7 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                     type="password"
                     id="password"
                     autoComplete="current-password"
-                    value={password}
-                    onChange={(e) => {
-                      setPassword(e.target.value);
-                    }}
+                    inputRef={register}
                   />
                 </Grid>
                 <Grid item xs={12}>
@@ -142,10 +141,7 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                     type="password"
                     id="passwordConfirmation"
                     autoComplete="current-password"
-                    value={passwordConfirmation}
-                    onChange={(e) => {
-                      setPasswordConfirmation(e.target.value);
-                    }}
+                    inputRef={register}
                   />
                 </Grid>
               </Grid>
@@ -155,7 +151,6 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                 variant="contained"
                 color="primary"
                 className={classes.submit}
-                onClick={handleSubmit}
               >
                 Sign Up
               </Button>

--- a/src/Signup.tsx
+++ b/src/Signup.tsx
@@ -63,7 +63,7 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const history = useHistory();
 
-  const { handleSubmit, register } = useForm<SignupFormData>();
+  const { handleSubmit, register, errors } = useForm<SignupFormData>();
 
   const handleOnSubmit = (data: SignupFormData) => {
     const { email, password, passwordConfirmation } = data;
@@ -115,7 +115,15 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                     label="Email"
                     name="email"
                     autoComplete="email"
-                    inputRef={register}
+                    inputRef={register({
+                      required: 'メールアドレスは必ず入力してください',
+                      pattern: {
+                        value: /^[\w+\-.]+@[a-z\d\-.]+\.[a-z]+$/,
+                        message: 'メールアドレスは正しい形式で入力してください',
+                      },
+                    })}
+                    error={!!errors.email}
+                    helperText={!!errors.email ? errors.email.message : ' '}
                   />
                 </Grid>
                 <Grid item xs={12}>
@@ -128,7 +136,19 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                     type="password"
                     id="password"
                     autoComplete="current-password"
-                    inputRef={register}
+                    inputRef={register({
+                      required: 'パスワードは必ず入力してください',
+                      minLength: {
+                        value: 8,
+                        message: 'パスワードは8文字以上で入力してください',
+                      },
+                    })}
+                    error={!!errors.password}
+                    helperText={
+                      !!errors.password
+                        ? errors.password.message
+                        : 'パスワードは8文字以上で入力してください'
+                    }
                   />
                 </Grid>
                 <Grid item xs={12}>
@@ -141,7 +161,19 @@ const Signup: FC<SignupProps> = ({ isLoggedIn, setIsLoggedIn }) => {
                     type="password"
                     id="passwordConfirmation"
                     autoComplete="current-password"
-                    inputRef={register}
+                    inputRef={register({
+                      required: 'パスワード（確認）は必ず入力してください',
+                      minLength: {
+                        value: 8,
+                        message: 'パスワード（確認）は8文字以上で入力してください',
+                      },
+                    })}
+                    error={!!errors.passwordConfirmation}
+                    helperText={
+                      !!errors.passwordConfirmation
+                        ? errors.passwordConfirmation.message
+                        : 'パスワード（確認）は8文字以上で入力してください'
+                    }
                   />
                 </Grid>
               </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8756,6 +8756,11 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
+react-hook-form@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-5.6.0.tgz#309fbd9780d5d091c6e96796d82d16e0cc5849eb"
+  integrity sha512-/WGDFdrkooe71SKV1IB5bRRWmPHohQW2GfEYivc1mRGEuTIKIzNeAeSLZzTUzAXMVXcoCk2147mb15QwkoyIng==
+
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
close #15 

### やったこと
- [React Hook Form](https://react-hook-form.com/jp/)のインストール
- React Hook Formでバリデーションを実装
- エラーメッセージとヘルパーテキストをmaterial-uiのコンポーネントで表示

### 参考サイト
- [React Hook Form で超簡単にバリデーションする方法 | webOpixel](https://www.webopixel.net/javascript/1606.html)
- [Railsの正規表現でよく使われる \A \z って何？？ - Qiita](https://qiita.com/jnchito/items/ea7832df6f64a9034872)
- [Text Field React component - Material-UI](https://material-ui.com/components/text-fields/)