### PR TITLE
ログインステータスを受け取る前にコンテンツ部分をrenderしないように修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import SignUp from './Signup';
 import Auth from './Auth';
 
 const App: FC = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState<null | boolean>(null);
 
   const history = useHistory();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,23 +58,28 @@ const App: FC = () => {
         </ul>
       </nav>
 
-      <Switch>
-        <Route
-          exact
-          path="/login"
-          render={() => <Login isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
-        />
-        <Route
-          exact
-          path="/signup"
-          render={() => <SignUp isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
-        />
-        <Auth isLoggedIn={isLoggedIn}>
-          <Route path="/about" component={About} exact />
-          <Route path="/" component={Home} />
-        </Auth>
-        <Redirect to="/" />
-      </Switch>
+      {
+        isLoggedIn === null
+          ? '読み込み中' // TODO: ローディング用のコンポーネントに差し替え
+          :
+            <Switch>
+              <Route
+                exact
+                path="/login"
+                render={() => <Login isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
+              />
+              <Route
+                exact
+                path="/signup"
+                render={() => <SignUp isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />}
+              />
+              <Auth isLoggedIn={isLoggedIn}>
+                <Route path="/about" component={About} exact />
+                <Route path="/" component={Home} />
+              </Auth>
+              <Redirect to="/" />
+            </Switch>
+      }
     </React.Fragment>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const App: FC = () => {
 
   return (
     <React.Fragment>
+      {/* TODO: ヘッダーは別コンポーネントに切り出す */}
       <nav>
         <ul>
           <li>

--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { Redirect } from 'react-router-dom';
 
 type Props = {
-  isLoggedIn: boolean;
+  isLoggedIn: null | boolean;
 };
 
 const Auth: FC<Props> = ({ isLoggedIn, children }) => {

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -45,8 +45,8 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 type LoginProps = {
-  isLoggedIn: boolean;
-  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
+  isLoggedIn: null | boolean;
+  setIsLoggedIn: React.Dispatch<React.SetStateAction<null | boolean>>;
 };
 
 type LoginFormData = {

--- a/src/Signup.tsx
+++ b/src/Signup.tsx
@@ -48,8 +48,8 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 type SignupProps = {
-  isLoggedIn: boolean;
-  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
+  isLoggedIn: null | boolean;
+  setIsLoggedIn: React.Dispatch<React.SetStateAction<null | boolean>>;
 };
 
 type SignupFormData = {


### PR DESCRIPTION
close #18 

### やったこと
- ログイン状態を持つstate（`isLoggedIn `）をnullとbooleanのunion型に変更
- `isLoggedIn`がnullの場合は「読み込み中」と表示する
  - 今後何かしらローディング用のコンポーネントに差し替えたい
- `isLoggedIn`がbooleanの場合はアプリのメインのコンポーネントを表示
- 上記のようにすることで、ログインしているのに１回非ログイン判定でコンポーネントがrendeされることを防ぐ

### 参考
- [Update on Async Rendering – React Blog](https://ja.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data)