### PR TITLE
Implement menu create form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,7 @@ import Auth from './components/Auth';
 import Snackbar from './components/Snackbar';
 import Loading from './components/Loading';
 
-export enum SnackbarSeverity {
-  ERROR = 'error',
-  WARNING = 'warning',
-  INFO = 'info',
-  SUCCESS = 'success',
-}
+import { SnackbarSeverity } from './constants';
 
 const App: FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState<null | boolean>(null);

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { Redirect } from 'react-router-dom';
-import { SnackbarSeverity } from '../App';
+import { SnackbarSeverity } from '../constants';
 
 type Props = {
   isLoggedIn: null | boolean;

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -3,7 +3,7 @@ import Snackbar, { SnackbarCloseReason } from '@material-ui/core/Snackbar';
 import MuiAlert from '@material-ui/lab/Alert';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { SnackbarSeverity } from '../App';
+import { SnackbarSeverity } from '../constants';
 
 type alertProps = {
   severity: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,6 @@
+export enum SnackbarSeverity {
+    ERROR = 'error',
+    WARNING = 'warning',
+    INFO = 'info',
+    SUCCESS = 'success',
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -14,7 +14,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import { apiClient } from '../lib/axios';
 
-import { SnackbarSeverity } from '../App';
+import { SnackbarSeverity } from '../constants';
 
 function Copyright() {
   return (

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -133,7 +133,7 @@ const New: FC = () => {
   }
 
   return (
-    <Container component="main" maxWidth="md" className={classes.root}>
+    <Container component="main" maxWidth="xl" className={classes.root}>
       <CssBaseline />
       <Typography component="h2" variant="h4" align="center" className={classes.heading}>
         部位追加

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -21,16 +21,25 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     partForm: {
       textAlign: 'center',
+      marginBottom: theme.spacing(10),
     },
     addPartBtn: {
       marginTop: theme.spacing(4.5),
       marginLeft: theme.spacing(3),
+    },
+    menuForm: {
+      textAlign: 'center',
     },
   })
 );
 
 type PartFormData = {
   name: string;
+};
+
+type MenuFormData = {
+  name: string;
+  id: string;
 };
 
 const New: FC = () => {
@@ -49,9 +58,11 @@ const New: FC = () => {
 
   const classes = useStyles();
 
+  // 分けて宣言しないと別フォームのバリデーションにならないので、一旦こうしている
   const { handleSubmit, register, errors, reset } = useForm<PartFormData>();
+  const menuForm = useForm<MenuFormData>();
 
-  const handleClickSubmitBtn = (data: PartFormData) => {
+  const handleClickAddPartBtn = (data: PartFormData) => {
     apiClient
       .post('/parts', {
         part: {
@@ -60,6 +71,27 @@ const New: FC = () => {
       })
       .then((res) => {
         reset({ name: '' });
+        setIsOpenSnackbar(true);
+        setSnackbarSeverity(SnackbarSeverity.SUCCESS);
+        setSnackbarMessage(res.data.message);
+      })
+      .catch((error) => {
+        setIsOpenSnackbar(true);
+        setSnackbarSeverity(SnackbarSeverity.ERROR);
+        setSnackbarMessage('部位の作成に失敗しました');
+      });
+  };
+
+  const handleClickAddMenuBtn = (data: MenuFormData) => {
+    const { id, name } = data;
+    apiClient
+      .post(`/parts/${id}/menus`, {
+        part: {
+          name: name,
+        },
+      })
+      .then((res) => {
+        menuForm.reset({ name: '' });
         setIsOpenSnackbar(true);
         setSnackbarSeverity(SnackbarSeverity.SUCCESS);
         setSnackbarMessage(res.data.message);
@@ -85,7 +117,7 @@ const New: FC = () => {
         className={classes.partForm}
         noValidate
         autoComplete="off"
-        onSubmit={handleSubmit(handleClickSubmitBtn)}
+        onSubmit={handleSubmit(handleClickAddPartBtn)}
       >
         <TextField
           variant="outlined"
@@ -104,6 +136,38 @@ const New: FC = () => {
           })}
           error={!!errors.name}
           helperText={!!errors.name && errors.name.message}
+        />
+        <Button type="submit" variant="contained" color="primary" className={classes.addPartBtn}>
+          追加
+        </Button>
+      </form>
+
+      <Typography component="h2" variant="h4" align="center" className={classes.heading}>
+        メニュー追加
+      </Typography>
+      <form
+        className={classes.menuForm}
+        noValidate
+        autoComplete="off"
+        onSubmit={menuForm.handleSubmit(handleClickAddMenuBtn)}
+      >
+        <TextField
+          variant="outlined"
+          margin="normal"
+          required
+          name="name"
+          label="部位名"
+          type="text"
+          id="name"
+          inputRef={menuForm.register({
+            required: 'メニュー名は必ず入力してください',
+            maxLength: {
+              value: 50,
+              message: 'メニュー名は50文字以内で入力してください',
+            },
+          })}
+          error={!!menuForm.errors.name}
+          helperText={!!menuForm.errors.name && menuForm.errors.name.message}
         />
         <Button type="submit" variant="contained" color="primary" className={classes.addPartBtn}>
           追加

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -95,6 +95,7 @@ const New: FC = () => {
       })
       .then((res) => {
         reset({ name: '' });
+        setParts([...parts, res.data.part]);
         setIsOpenSnackbar(true);
         setSnackbarSeverity(SnackbarSeverity.SUCCESS);
         setSnackbarMessage(res.data.message);

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
@@ -7,6 +7,8 @@ import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import { apiClient } from '../lib/axios';
+import { SnackbarSeverity } from '../constants';
+import Snackbar from '../components/Snackbar';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -29,6 +31,10 @@ type PartFormData = {
 };
 
 const New: FC = () => {
+  const [isOpenSnackbar, setIsOpenSnackbar] = useState(false);
+  const [snackbarSeverity, setSnackbarSeverity] = useState(SnackbarSeverity.SUCCESS);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
   const classes = useStyles();
 
   const { handleSubmit, register, errors, reset } = useForm<PartFormData>();
@@ -43,11 +49,14 @@ const New: FC = () => {
       .then((res) => {
         reset({ name: '' });
         // res.data.partで追加した部位の情報取れる
-
-        // TODO: snackBar表示させたい
+        setIsOpenSnackbar(true);
+        setSnackbarSeverity(SnackbarSeverity.SUCCESS);
+        setSnackbarMessage('部位を作成しました');
       })
       .catch((error) => {
-        // TODO: snackBar表示させたい
+        setIsOpenSnackbar(true);
+        setSnackbarSeverity(SnackbarSeverity.ERROR);
+        setSnackbarMessage('部位の作成に失敗しました');
       });
   };
 
@@ -86,6 +95,12 @@ const New: FC = () => {
           </Button>
         </form>
       </Typography>
+      <Snackbar
+        isOpenSnackbar={isOpenSnackbar}
+        setIsOpenSnackbar={setIsOpenSnackbar}
+        snackbarSeverity={snackbarSeverity}
+        snackbarMessage={snackbarMessage}
+      />
     </Container>
   );
 };

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -1,11 +1,16 @@
 import React, { FC, useState, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
 import { apiClient } from '../lib/axios';
 import { SnackbarSeverity } from '../constants';
 import Snackbar from '../components/Snackbar';
@@ -23,12 +28,23 @@ const useStyles = makeStyles((theme: Theme) =>
       textAlign: 'center',
       marginBottom: theme.spacing(10),
     },
-    addPartBtn: {
+    addBtn: {
       marginTop: theme.spacing(4.5),
       marginLeft: theme.spacing(3),
     },
     menuForm: {
       textAlign: 'center',
+    },
+    formControl: {
+      marginRight: theme.spacing(2),
+      marginTop: theme.spacing(2),
+      minWidth: 120,
+    },
+    menuSelectField: {
+      verticalAlign: 'center',
+    },
+    menuTextField: {
+      minWidth: 250,
     },
   })
 );
@@ -39,12 +55,20 @@ type PartFormData = {
 
 type MenuFormData = {
   name: string;
+  partID: string;
+};
+
+type partData = {
   id: string;
+  name: string;
+  user_id?: string;
+  created_at?: string;
+  updated_at?: string;
 };
 
 const New: FC = () => {
   const [isLoading, setIsLoading] = useState(true);
-  const [parts, setParts] = useState([]);
+  const [parts, setParts] = useState<partData[]>([]);
   const [isOpenSnackbar, setIsOpenSnackbar] = useState(false);
   const [snackbarSeverity, setSnackbarSeverity] = useState(SnackbarSeverity.SUCCESS);
   const [snackbarMessage, setSnackbarMessage] = useState('');
@@ -83,10 +107,10 @@ const New: FC = () => {
   };
 
   const handleClickAddMenuBtn = (data: MenuFormData) => {
-    const { id, name } = data;
+    const { partID, name } = data;
     apiClient
-      .post(`/parts/${id}/menus`, {
-        part: {
+      .post(`/parts/${partID}/menus`, {
+        menu: {
           name: name,
         },
       })
@@ -99,7 +123,7 @@ const New: FC = () => {
       .catch((error) => {
         setIsOpenSnackbar(true);
         setSnackbarSeverity(SnackbarSeverity.ERROR);
-        setSnackbarMessage('部位の作成に失敗しました');
+        setSnackbarMessage('メニューの作成に失敗しました');
       });
   };
 
@@ -108,7 +132,7 @@ const New: FC = () => {
   }
 
   return (
-    <Container component="main" maxWidth="xs" className={classes.root}>
+    <Container component="main" maxWidth="md" className={classes.root}>
       <CssBaseline />
       <Typography component="h2" variant="h4" align="center" className={classes.heading}>
         部位追加
@@ -137,7 +161,7 @@ const New: FC = () => {
           error={!!errors.name}
           helperText={!!errors.name && errors.name.message}
         />
-        <Button type="submit" variant="contained" color="primary" className={classes.addPartBtn}>
+        <Button type="submit" variant="contained" color="primary" className={classes.addBtn}>
           追加
         </Button>
       </form>
@@ -151,14 +175,37 @@ const New: FC = () => {
         autoComplete="off"
         onSubmit={menuForm.handleSubmit(handleClickAddMenuBtn)}
       >
+        <FormControl variant="outlined" className={classes.formControl}>
+          <InputLabel id="menu-select-label">部位</InputLabel>
+          <Controller
+            as={
+              <Select error={!!menuForm.errors.partID}>
+                {parts.map((part) => {
+                  return (
+                    <MenuItem value={part.id} key={part.id}>
+                      {part.name}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            }
+            name="partID"
+            rules={{ required: '部位は必須です' }}
+            control={menuForm.control}
+          />
+          <FormHelperText error={true}>
+            {!!menuForm.errors.partID && menuForm.errors.partID.message}
+          </FormHelperText>
+        </FormControl>
         <TextField
           variant="outlined"
           margin="normal"
           required
           name="name"
-          label="部位名"
+          label="メニュー名"
           type="text"
           id="name"
+          className={classes.menuTextField}
           inputRef={menuForm.register({
             required: 'メニュー名は必ず入力してください',
             maxLength: {
@@ -169,7 +216,7 @@ const New: FC = () => {
           error={!!menuForm.errors.name}
           helperText={!!menuForm.errors.name && menuForm.errors.name.message}
         />
-        <Button type="submit" variant="contained" color="primary" className={classes.addPartBtn}>
+        <Button type="submit" variant="contained" color="primary" className={classes.addBtn}>
           追加
         </Button>
       </form>

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
@@ -9,6 +9,7 @@ import Button from '@material-ui/core/Button';
 import { apiClient } from '../lib/axios';
 import { SnackbarSeverity } from '../constants';
 import Snackbar from '../components/Snackbar';
+import Loading from '../components/Loading';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -31,9 +32,19 @@ type PartFormData = {
 };
 
 const New: FC = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [parts, setParts] = useState([]);
   const [isOpenSnackbar, setIsOpenSnackbar] = useState(false);
   const [snackbarSeverity, setSnackbarSeverity] = useState(SnackbarSeverity.SUCCESS);
   const [snackbarMessage, setSnackbarMessage] = useState('');
+
+  useEffect(() => {
+    apiClient.get('/parts').then((res) => {
+      debugger;
+      setParts(res.data);
+      setIsLoading(false);
+    });
+  }, []);
 
   const classes = useStyles();
 
@@ -48,10 +59,9 @@ const New: FC = () => {
       })
       .then((res) => {
         reset({ name: '' });
-        // res.data.partで追加した部位の情報取れる
         setIsOpenSnackbar(true);
         setSnackbarSeverity(SnackbarSeverity.SUCCESS);
-        setSnackbarMessage('部位を作成しました');
+        setSnackbarMessage(res.data.message);
       })
       .catch((error) => {
         setIsOpenSnackbar(true);
@@ -59,6 +69,10 @@ const New: FC = () => {
         setSnackbarMessage('部位の作成に失敗しました');
       });
   };
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <Container component="main" maxWidth="xs" className={classes.root}>

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -42,7 +42,6 @@ const New: FC = () => {
 
   useEffect(() => {
     apiClient.get('/parts').then((res) => {
-      debugger;
       setParts(res.data);
       setIsLoading(false);
     });

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -19,7 +19,9 @@ const useStyles = makeStyles((theme: Theme) =>
     heading: {
       marginBottom: theme.spacing(3),
     },
-    partForm: {},
+    partForm: {
+      textAlign: 'center',
+    },
     addPartBtn: {
       marginTop: theme.spacing(4.5),
       marginLeft: theme.spacing(3),
@@ -79,36 +81,35 @@ const New: FC = () => {
       <CssBaseline />
       <Typography component="h2" variant="h4" align="center" className={classes.heading}>
         部位追加
-        <form
-          className=""
-          noValidate
-          autoComplete="off"
-          onSubmit={handleSubmit(handleClickSubmitBtn)}
-        >
-          <TextField
-            className={classes.partForm}
-            variant="outlined"
-            margin="normal"
-            required
-            name="name"
-            label="部位名"
-            type="text"
-            id="name"
-            inputRef={register({
-              required: '部位名は必ず入力してください',
-              maxLength: {
-                value: 30,
-                message: '部位名は30文字以内で入力してください',
-              },
-            })}
-            error={!!errors.name}
-            helperText={!!errors.name && errors.name.message}
-          />
-          <Button type="submit" variant="contained" color="primary" className={classes.addPartBtn}>
-            追加
-          </Button>
-        </form>
       </Typography>
+      <form
+        className={classes.partForm}
+        noValidate
+        autoComplete="off"
+        onSubmit={handleSubmit(handleClickSubmitBtn)}
+      >
+        <TextField
+          variant="outlined"
+          margin="normal"
+          required
+          name="name"
+          label="部位名"
+          type="text"
+          id="name"
+          inputRef={register({
+            required: '部位名は必ず入力してください',
+            maxLength: {
+              value: 30,
+              message: '部位名は30文字以内で入力してください',
+            },
+          })}
+          error={!!errors.name}
+          helperText={!!errors.name && errors.name.message}
+        />
+        <Button type="submit" variant="contained" color="primary" className={classes.addPartBtn}>
+          追加
+        </Button>
+      </form>
       <Snackbar
         isOpenSnackbar={isOpenSnackbar}
         setIsOpenSnackbar={setIsOpenSnackbar}

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -14,7 +14,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import { apiClient } from '../lib/axios';
 
-import { SnackbarSeverity } from '../App';
+import { SnackbarSeverity } from '../constants';
 
 function Copyright() {
   return (


### PR DESCRIPTION
close: #36 

### やったこと
- `/new`ページにメニュー追加フォームを実装
  - material-uiのselectMenuとreact-hook-formのつなぎの部分に少し詰まったけど、https://github.com/react-hook-form/react-hook-form/issues/497 を参考に解決
  - 複数のフォームを同じページに表示する部分が多少無理矢理
- snackBarの表示
  - global stateで管理するのは一旦やめた
  - #38 で試したけど、色々問題起きたので多少無理矢理でもバケツリレーで頑張ることにする
  - `SnackbarSeverity`を`src/constants.ts`に移した
- 部位追加後にローカルステートの更新
  - 部位追加すると、メニュー追加用のセレクトメニューにもそのまま追加されるようになった