### PR TITLE
Implement index page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import New from './pages/New';
 import Output from './pages/Output';
 import Login from './pages/Login';
 import SignUp from './pages/Signup';
+import Index from './pages/Index';
 import Header from './components/Header';
 import Auth from './components/Auth';
 import Snackbar from './components/Snackbar';
@@ -87,6 +88,7 @@ const App: FC = () => {
         >
           <Route path="/" component={Output} exact />
           <Route path="/new" component={New} exact />
+          <Route path="/index" component={Index} exact />
         </Auth>
         <Redirect to="/" />
       </Switch>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,6 +46,11 @@ const Header: FC<HeaderProps> = ({ isLoggedIn, handleClickLogout }) => {
                 </Link>
               </Button>
               <Button color="inherit">
+                <Link to="/index" className={classes.text}>
+                  メニュー一覧
+                </Link>
+              </Button>
+              <Button color="inherit">
                 <Link to="/new" className={classes.text}>
                   メニュー追加
                 </Link>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect, FC } from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Container from '@material-ui/core/Container';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Typography from '@material-ui/core/Typography';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemText from '@material-ui/core/ListItemText';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
+import { apiClient } from '../lib/axios';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      marginTop: theme.spacing(5),
+    },
+    heading: {
+      marginBottom: theme.spacing(3),
+    },
+    listRoot: {
+      width: '100%',
+      maxHeight: 300,
+      maxWidth: 400,
+      margin: 'auto',
+      overflow: 'auto',
+    },
+  })
+);
+
+interface Part {
+  id: number;
+  name: string;
+}
+
+interface Menu {
+  id: number;
+  name: string;
+}
+
+interface PartWithMenu {
+  id: number;
+  name: string;
+  menus: Menu[];
+}
+
+const Index: FC = () => {
+  const classes = useStyles();
+
+  const [partWithMenus, setPartWithMenus] = useState<PartWithMenu[]>([]);
+
+  useEffect(() => {
+    apiClient
+      .get('parts?include_menus=true')
+      .then((res) => {
+        setPartWithMenus(res.data);
+      })
+      .catch((err) => {
+        // TODO: エラーハンドリング
+        console.log(err);
+      });
+  }, []);
+
+  const handleCilckDeleteIcon = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    console.log(e.currentTarget.id);
+  };
+
+  const parts: Part[] = [];
+  partWithMenus.forEach((partWithMenu) => {
+    const part: Part = {
+      id: partWithMenu.id,
+      name: partWithMenu.name,
+    };
+    parts.push(part);
+  });
+
+  return (
+    <Container component="main" maxWidth="xl" className={classes.root}>
+      <CssBaseline />
+      <Typography component="h1" variant="h4" align="center" className={classes.heading}>
+        部位一覧
+      </Typography>
+      <List className={classes.listRoot}>
+        {parts.map((part, i) => {
+          return (
+            <ListItem divider={true} key={i}>
+              <ListItemText primary={part.name} />
+              <ListItemSecondaryAction id={`${part.id}`} onClick={(e) => handleCilckDeleteIcon(e)}>
+                <IconButton edge="end" aria-label="delete">
+                  <DeleteIcon />
+                </IconButton>
+              </ListItemSecondaryAction>
+            </ListItem>
+          );
+        })}
+      </List>
+    </Container>
+  );
+};
+
+export default Index;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, FC } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import Container from '@material-ui/core/Container';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Typography from '@material-ui/core/Typography';
 import List from '@material-ui/core/List';

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -91,7 +91,26 @@ const Index: FC = () => {
   });
 
   const handleCilckPartDeleteIcon = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    console.log(e.currentTarget.id);
+    e.persist();
+    const partId = e.currentTarget.id;
+    const indexNum = (e.currentTarget.dataset.index as unknown) as number;
+
+    apiClient
+      .delete(`/parts/${partId}`)
+      .then((res) => {
+        console.log('deleted!!!!');
+
+        const coppiedParts = [...partWithMenus];
+        coppiedParts.splice(indexNum, 1);
+
+        setPartWithMenus(coppiedParts);
+
+        // TODO: snackBarの表示
+      })
+      .catch((error) => {
+        console.log(error);
+        // TODO: snackBarの表示
+      });
   };
 
   const handleChangeSelectMenu = (
@@ -133,6 +152,7 @@ const Index: FC = () => {
                 <ListItemText primary={part.name} />
                 <ListItemSecondaryAction
                   id={`${part.id}`}
+                  data-index={i}
                   onClick={(e) => handleCilckPartDeleteIcon(e)}
                 >
                   <IconButton edge="end" aria-label="delete">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
+import Grid from '@material-ui/core/Grid';
 
 import Loading from '../components/Loading';
 import { apiClient } from '../lib/axios';
@@ -20,14 +21,14 @@ import { apiClient } from '../lib/axios';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      marginTop: theme.spacing(5),
+      padding: theme.spacing(4),
     },
     heading: {
       marginBottom: theme.spacing(3),
     },
     listRoot: {
       width: '100%',
-      maxHeight: 300,
+      maxHeight: 400,
       maxWidth: 400,
       margin: 'auto',
       marginBottom: theme.spacing(10),
@@ -119,63 +120,67 @@ const Index: FC = () => {
   }
 
   return (
-    <Container component="main" maxWidth="xl" className={classes.root}>
+    <Grid container className={classes.root} spacing={4}>
       <CssBaseline />
-      <Typography component="h1" variant="h4" align="center" className={classes.heading}>
-        部位一覧
-      </Typography>
-      <List className={classes.listRoot}>
-        {parts.map((part, i) => {
-          return (
-            <ListItem divider={true} key={i}>
-              <ListItemText primary={part.name} />
-              <ListItemSecondaryAction
-                id={`${part.id}`}
-                onClick={(e) => handleCilckPartDeleteIcon(e)}
-              >
-                <IconButton edge="end" aria-label="delete">
-                  <DeleteIcon />
-                </IconButton>
-              </ListItemSecondaryAction>
-            </ListItem>
-          );
-        })}
-      </List>
-      <Typography component="h1" variant="h4" align="center" className={classes.heading}>
-        メニュー一覧
-      </Typography>
-      <div className={classes.selectFormWrapper}>
-        <FormControl variant="outlined" className={classes.formControl}>
-          <InputLabel id="menu-select-label">部位</InputLabel>
-          <Select defaultValue="" onChange={(e) => handleChangeSelectMenu(e)}>
-            {parts.map((part) => {
-              return (
-                <MenuItem value={part.id} key={part.id}>
-                  {part.name}
-                </MenuItem>
-              );
-            })}
-          </Select>
-        </FormControl>
-      </div>
-      <List className={classes.listRoot}>
-        {menus.map((menu, i) => {
-          return (
-            <ListItem divider={true} key={i}>
-              <ListItemText primary={menu.name} />
-              <ListItemSecondaryAction
-                id={`${menu.id}`}
-                onClick={(e) => handleCilckMenuDeleteIcon(e)}
-              >
-                <IconButton edge="end" aria-label="delete">
-                  <DeleteIcon />
-                </IconButton>
-              </ListItemSecondaryAction>
-            </ListItem>
-          );
-        })}
-      </List>
-    </Container>
+      <Grid item xs={12} sm={6}>
+        <Typography component="h1" variant="h4" align="center" className={classes.heading}>
+          部位一覧
+        </Typography>
+        <List className={classes.listRoot}>
+          {parts.map((part, i) => {
+            return (
+              <ListItem divider={true} key={i}>
+                <ListItemText primary={part.name} />
+                <ListItemSecondaryAction
+                  id={`${part.id}`}
+                  onClick={(e) => handleCilckPartDeleteIcon(e)}
+                >
+                  <IconButton edge="end" aria-label="delete">
+                    <DeleteIcon />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
+            );
+          })}
+        </List>
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <Typography component="h1" variant="h4" align="center" className={classes.heading}>
+          メニュー一覧
+        </Typography>
+        <div className={classes.selectFormWrapper}>
+          <FormControl variant="outlined" className={classes.formControl}>
+            <InputLabel id="menu-select-label">部位</InputLabel>
+            <Select defaultValue="" onChange={(e) => handleChangeSelectMenu(e)}>
+              {parts.map((part) => {
+                return (
+                  <MenuItem value={part.id} key={part.id}>
+                    {part.name}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        </div>
+        <List className={classes.listRoot}>
+          {menus.map((menu, i) => {
+            return (
+              <ListItem divider={true} key={i}>
+                <ListItemText primary={menu.name} />
+                <ListItemSecondaryAction
+                  id={`${menu.id}`}
+                  onClick={(e) => handleCilckMenuDeleteIcon(e)}
+                >
+                  <IconButton edge="end" aria-label="delete">
+                    <DeleteIcon />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
+            );
+          })}
+        </List>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,8 +7,14 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import ListItemText from '@material-ui/core/ListItemText';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
+
+import Loading from '../components/Loading';
 import { apiClient } from '../lib/axios';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -24,7 +30,16 @@ const useStyles = makeStyles((theme: Theme) =>
       maxHeight: 300,
       maxWidth: 400,
       margin: 'auto',
+      marginBottom: theme.spacing(10),
       overflow: 'auto',
+    },
+    formControl: {
+      margin: 'auto',
+      marginTop: theme.spacing(2),
+      minWidth: 120,
+    },
+    selectFormWrapper: {
+      textAlign: 'center',
     },
   })
 );
@@ -48,23 +63,22 @@ interface PartWithMenu {
 const Index: FC = () => {
   const classes = useStyles();
 
+  const [isLoading, setIsLoading] = useState(true);
   const [partWithMenus, setPartWithMenus] = useState<PartWithMenu[]>([]);
+  const [menus, setMenus] = useState<Menu[]>([]);
 
   useEffect(() => {
     apiClient
       .get('parts?include_menus=true')
       .then((res) => {
         setPartWithMenus(res.data);
+        setIsLoading(false);
       })
       .catch((err) => {
         // TODO: エラーハンドリング
         console.log(err);
       });
   }, []);
-
-  const handleCilckDeleteIcon = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    console.log(e.currentTarget.id);
-  };
 
   const parts: Part[] = [];
   partWithMenus.forEach((partWithMenu) => {
@@ -74,6 +88,35 @@ const Index: FC = () => {
     };
     parts.push(part);
   });
+
+  const handleCilckPartDeleteIcon = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    console.log(e.currentTarget.id);
+  };
+
+  const handleChangeSelectMenu = (
+    e: React.ChangeEvent<{
+      name?: string | undefined;
+      value: unknown;
+    }>
+  ) => {
+    const targetPart = partWithMenus.find((partWithMenu) => {
+      return partWithMenu.id === e.target.value;
+    });
+
+    if (targetPart == null) {
+      return;
+    }
+
+    setMenus(targetPart.menus);
+  };
+
+  const handleCilckMenuDeleteIcon = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    console.log(e.currentTarget.id);
+  };
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <Container component="main" maxWidth="xl" className={classes.root}>
@@ -86,7 +129,44 @@ const Index: FC = () => {
           return (
             <ListItem divider={true} key={i}>
               <ListItemText primary={part.name} />
-              <ListItemSecondaryAction id={`${part.id}`} onClick={(e) => handleCilckDeleteIcon(e)}>
+              <ListItemSecondaryAction
+                id={`${part.id}`}
+                onClick={(e) => handleCilckPartDeleteIcon(e)}
+              >
+                <IconButton edge="end" aria-label="delete">
+                  <DeleteIcon />
+                </IconButton>
+              </ListItemSecondaryAction>
+            </ListItem>
+          );
+        })}
+      </List>
+      <Typography component="h1" variant="h4" align="center" className={classes.heading}>
+        メニュー一覧
+      </Typography>
+      <div className={classes.selectFormWrapper}>
+        <FormControl variant="outlined" className={classes.formControl}>
+          <InputLabel id="menu-select-label">部位</InputLabel>
+          <Select defaultValue="" onChange={(e) => handleChangeSelectMenu(e)}>
+            {parts.map((part) => {
+              return (
+                <MenuItem value={part.id} key={part.id}>
+                  {part.name}
+                </MenuItem>
+              );
+            })}
+          </Select>
+        </FormControl>
+      </div>
+      <List className={classes.listRoot}>
+        {menus.map((menu, i) => {
+          return (
+            <ListItem divider={true} key={i}>
+              <ListItemText primary={menu.name} />
+              <ListItemSecondaryAction
+                id={`${menu.id}`}
+                onClick={(e) => handleCilckMenuDeleteIcon(e)}
+              >
                 <IconButton edge="end" aria-label="delete">
                   <DeleteIcon />
                 </IconButton>

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -95,7 +95,7 @@ const New: FC = () => {
       })
       .then((res) => {
         reset({ name: '' });
-        setParts([...parts, res.data.part]);
+        setParts([res.data.part, ...parts]);
         setIsOpenSnackbar(true);
         setSnackbarSeverity(SnackbarSeverity.SUCCESS);
         setSnackbarMessage(res.data.message);

--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -191,6 +191,7 @@ const New: FC = () => {
               </Select>
             }
             name="partID"
+            defaultValue=""
             rules={{ required: '部位は必須です' }}
             control={menuForm.control}
           />


### PR DESCRIPTION
close: #42 

### やったこと
- `Index`コンポーネントの作成
- 部位の一覧・削除機能の実装
  - メニュー一覧で選択中の部位を削除した場合は、その部位とメニューをリセットする
- メニューの一覧・削除機能の実装

### 参考記事
- IDの取得: [javascript - Getting ID from div in React.js - Stack Overflow](https://stackoverflow.com/questions/50956462/getting-id-from-div-in-react-js/50956718)
- e.persist()について: [合成イベント (SyntheticEvent) – React](https://ja.reactjs.org/docs/events.html)
- reactでデータ属性使う方法: [Reactのeventハンドリングの際に、DOMのカスタム属性にアクセスする - Qiita](https://qiita.com/Statham/items/8a07104153973bb25d64)
- 型変換: [TypeScript で文字列から数値型に変換する方法 - Corredor](https://neos21.hatenablog.com/entry/2017/09/16/080000)
  - `parseInt`とかすぐに思いつきそうだったのにここでやたら時間溶かした、、、